### PR TITLE
webapi: input function

### DIFF
--- a/examples/common/webapi.c
+++ b/examples/common/webapi.c
@@ -22,6 +22,16 @@ void webapi_init(const webapi_desc_t* desc) {
     if (before_init_state.dbg_connect_requested && state.funcs.dbg_connect) {
         state.funcs.dbg_connect();
     }
+
+    /* Wrap _webapi_input so we don't need to sweat the string to char* conversion in JavaScript */
+    EM_ASM({
+        const saveWebInput = Module["_webapi_input"];
+        Module["_webapi_input"] = function(text) {
+            const utf8 = stringToNewUTF8(text);
+            saveWebInput(utf8);
+            Module["_webapi_free"](utf8);
+        }
+    });
 }
 
 #if defined(__EMSCRIPTEN__)
@@ -190,6 +200,15 @@ EMSCRIPTEN_KEEPALIVE uint8_t* webapi_dbg_read_memory(uint16_t addr, int num_byte
         return ptr;
     } else {
         return 0;
+    }
+}
+
+EMSCRIPTEN_KEEPALIVE bool webapi_input(char* text) {
+    if (state.funcs.input != NULL && text != NULL) {
+        state.funcs.input(text);
+        return true;
+    } else {
+        return false;
     }
 }
 

--- a/examples/common/webapi.h
+++ b/examples/common/webapi.h
@@ -88,6 +88,7 @@ typedef struct {
     webapi_cpu_state_t (*dbg_cpu_state)(void);
     void (*dbg_request_disassembly)(uint16_t addr, int offset_lines, int num_lines, webapi_dasm_line_t* dst_lines);
     void (*dbg_read_memory)(uint16_t addr, int num_bytes, uint8_t* dst_ptr);
+    void (*input)(char* text);
 } webapi_interface_t;
 
 typedef struct {

--- a/examples/sokol/cpc.c
+++ b/examples/sokol/cpc.c
@@ -73,6 +73,7 @@ static void web_boot(void);
 static void web_reset(void);
 static bool web_ready(void);
 static bool web_load(chips_range_t data);
+static void web_input(char*);
 static void web_dbg_connect(void);
 static void web_dbg_disconnect(void);
 static void web_dbg_add_breakpoint(uint16_t addr);
@@ -222,6 +223,7 @@ void app_init(void) {
                 .dbg_cpu_state = web_dbg_cpu_state,
                 .dbg_request_disassembly = web_dbg_request_disassemly,
                 .dbg_read_memory = web_dbg_read_memory,
+                .input = web_input,
             }
         });
     #endif
@@ -545,6 +547,10 @@ static bool web_load(chips_range_t data) {
         }
     }
     return loaded;
+}
+
+static void web_input(char* text) {
+    keybuf_put(text);
 }
 
 static void web_dbg_add_breakpoint(uint16_t addr) {


### PR DESCRIPTION
This PR adds a `_webapi_input` function that lets you pass in a string and have it input / typed into the machine (in this case I've only added support for the CPC). I've used some `EM_ASM` to wrap the published function to handle the annoying `stringToNewUTF8` dance. It's pretty slow typing, but it gets there!