### PR TITLE
fix: _webapi_input gets rewritten to native function after being called

### DIFF
--- a/examples/common/webapi.c
+++ b/examples/common/webapi.c
@@ -31,9 +31,11 @@ void webapi_init(const webapi_desc_t* desc) {
     #if defined(__EMSCRIPTEN__)
     EM_ASM({
         const cfunc = Module["_webapi_input"];
-        Module["_webapi_input"] = (text) => {
+        const nfunc = (text) => {
             withStackSave(() => cfunc(stringToUTF8OnStack(text)));
-        }
+            Module["_webapi_input"] = nfunc;
+        };
+        Module["_webapi_input"] = nfunc;
     });
     #endif
 }


### PR DESCRIPTION
The impact of this is that the first call to `Module._webapi_input` works, but the second call no longer has the benefit of the string conversion.

I feel like this is new, because this used to work. Something is rewriting _webapi_input to the native function after we call it. What I’ve done is a hack to change it back. It’s not the `withStackSave` stuff… it still does it with my original blander code.